### PR TITLE
Testing basics for Binary unit support

### DIFF
--- a/src/vss_tools/exporters/binary.py
+++ b/src/vss_tools/exporters/binary.py
@@ -115,6 +115,8 @@ def export_node(node: VSSNode, generate_uuid, f: BinaryIO):
 @clo.overlays_opt
 @clo.quantities_opt
 @clo.units_opt
+@clo.types_opt
+@clo.types_output_opt
 def cli(
     vspec: Path,
     output: Path,
@@ -126,6 +128,8 @@ def cli(
     overlays: tuple[Path],
     quantities: tuple[Path],
     units: tuple[Path],
+    types: tuple[Path],
+    types_output: Path,
 ):
     """
     Export to Binary.
@@ -140,6 +144,7 @@ def cli(
         uuid=uuid,
         quantities=quantities,
         units=units,
+        types=types,
         overlays=overlays,
     )
     log.info("Generating binary output...")


### PR DESCRIPTION
With this change I can run

```
erik@debian6:~/vss-tools/tests/vspec/test_structs$ vspec export binary --types VehicleDataTypes.vspec -u ../test_units.yaml -q ../test_quantities.yaml --vspec test.vspec --output hej.binary
[12:01:40] INFO     Loaded 'VSSQuantity', file=/home/erik/vss-tools/tests/vspec/test_structs/../test_quantities.yaml, elements=6           units_quantities.py:34
           INFO     Loaded 'VSSUnit', file=/home/erik/vss-tools/tests/vspec/test_structs/../test_units.yaml, elements=7                    units_quantities.py:34
           INFO     VSpecs (Types) loaded, amount=2                                                                                                  vspec.py:122
           INFO     Dynamic datatypes added=2                                                                                                         main.py:130
           INFO     VSpecs loaded, amount=1                                                                                                          vspec.py:122
           INFO     Generating binary output...                                                                                                     binary.py:150
           INFO     Binary output generated in hej.binary                                                                                           binary.py:153
erik@debian6:~/vss-tools/tests/vspec/test_structs$ 
```

For comparision, similar command works for yaml

```
erik@debian6:~/vss-tools/tests/vspec/test_structs$ vspec export yaml --types VehicleDataTypes.vspec -u ../test_units.yaml -q ../test_quantities.yaml --vspec test.vspec --output hej.yaml
[12:02:39] INFO     Loaded 'VSSQuantity', file=/home/erik/vss-tools/tests/vspec/test_structs/../test_quantities.yaml, elements=6           units_quantities.py:34
           INFO     Loaded 'VSSUnit', file=/home/erik/vss-tools/tests/vspec/test_structs/../test_units.yaml, elements=7                    units_quantities.py:34
           INFO     VSpecs (Types) loaded, amount=2                                                                                                  vspec.py:122
           INFO     Dynamic datatypes added=2                                                                                                         main.py:130
           INFO     VSpecs loaded, amount=1                                                                                                          vspec.py:122
           INFO     Generating YAML output...                                                                                                          yaml.py:97
           INFO     Adding custom data types to signal dictionary                                                                                     yaml.py:103
erik@debian6:~/vss-tools/tests/vspec/test_structs$ 
```


To verify that you work on expected commit, check `git log`

```
erik@debian6:~/vss-tools/tests/vspec/test_structs$ git log -2
commit d3ada0efe4888e5ed54a5d8ac0049ecaa8f5f8ea (HEAD -> erik_bin, origin/erik_bin)
Author: Erik Jaegervall <erik.jaegervall@se.bosch.com>
Date:   Wed Oct 23 11:58:47 2024 +0200

    Testing basics for Binary unit support
    
    Signed-off-by: Erik Jaegervall <erik.jaegervall@se.bosch.com>

commit 92d4873e38ec691b09de861fd40e62e68bb5f288 (upstream/master, origin/master, origin/HEAD)
Author: Sebastian Schleemilch <sebastian.schleemilch@bmw.de>
Date:   Mon Oct 14 13:58:18 2024 +0200

    Tidy directory and file names
    
    Signed-off-by: Sebastian Schleemilch <sebastian.schleemilch@bmw.de>
```



